### PR TITLE
Check whether we can drag card

### DIFF
--- a/app/src/main/java/com/daprlabs/aaron/swipedeck2/MainActivity.java
+++ b/app/src/main/java/com/daprlabs/aaron/swipedeck2/MainActivity.java
@@ -1,5 +1,8 @@
 package com.daprlabs.aaron.swipedeck2;
 
+import com.daprlabs.aaron.swipedeck.SwipeDeck;
+import com.squareup.picasso.Picasso;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -9,11 +12,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.TextView;
-
-import com.daprlabs.aaron.swipedeck.SwipeDeck;
-import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,12 +26,14 @@ public class MainActivity extends AppCompatActivity {
     private Context context = this;
     private SwipeDeckAdapter adapter;
     private ArrayList<String> testData;
+    private CheckBox dragCheckbox;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         cardStack = (SwipeDeck) findViewById(R.id.swipe_deck);
+        dragCheckbox = (CheckBox) findViewById(R.id.checkbox_drag);
 
         testData = new ArrayList<>();
         testData.add("0");
@@ -53,6 +56,11 @@ public class MainActivity extends AppCompatActivity {
             public void cardSwipedRight(long stableId) {
                 Log.i("MainActivity", "card was swiped right, position in adapter: " + stableId);
 
+            }
+
+            @Override
+            public boolean isDragEnabled(long itemId) {
+                return dragCheckbox.isChecked();
             }
         });
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,6 +11,7 @@
         android:id="@+id/swipe_deck"
         android:layout_width="match_parent"
         android:layout_height="650dp"
+        android:layout_gravity="center"
         android:paddingLeft="50dp"
         android:paddingRight="50dp"
         android:paddingTop="50dp"
@@ -36,5 +37,13 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|right"
         android:text="swipe right" />
+
+    <CheckBox
+        android:id="@+id/checkbox_drag"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|left"
+        android:checked="true"
+        android:text="Drag enabled"/>
 
 </com.daprlabs.aaron.swipedeck.layouts.SwipeFrameLayout>

--- a/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/SwipeDeck.java
+++ b/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/SwipeDeck.java
@@ -1,5 +1,8 @@
 package com.daprlabs.aaron.swipedeck;
 
+import com.daprlabs.aaron.swipedeck.Utility.Deck;
+import com.daprlabs.aaron.swipedeck.Utility.SwipeCallback;
+
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
@@ -10,13 +13,8 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewPropertyAnimator;
 import android.widget.Adapter;
 import android.widget.FrameLayout;
-
-import com.daprlabs.aaron.swipedeck.Utility.Deck;
-import com.daprlabs.aaron.swipedeck.Utility.RxBus;
-import com.daprlabs.aaron.swipedeck.Utility.SwipeCallback;
 
 import java.util.ArrayList;
 
@@ -183,46 +181,7 @@ public class SwipeDeck extends FrameLayout {
             newBottomChild.setY(getPaddingTop());
             final long viewId = mAdapter.getItemId(adapterIndex);
 
-            CardContainer card = new CardContainer(newBottomChild, this, new SwipeCallback() {
-                @Override
-                public void cardSwipedLeft(View card) {
-                    Log.d(TAG, "card swiped left");
-                    if (!(deck.getFront().getCard() == card)) {
-                        Log.e("SWIPE ERROR: ", "card on top of deck not equal to card swiped");
-                    }
-                    deck.removeFront();
-                    if (callback != null) {
-                        callback.cardSwipedLeft(viewId);
-                    }
-                }
-
-                @Override
-                public void cardSwipedRight(View card) {
-                    Log.d(TAG, "card swiped right");
-                    if (!(deck.getFront().getCard() == card)) {
-                        Log.e("SWIPE ERROR: ", "card on top of deck not equal to card swiped");
-                    }
-                    deck.removeFront();
-                    if (callback != null) {
-                        callback.cardSwipedRight(viewId);
-                    }
-                }
-
-                @Override
-                public void cardOffScreen(View card) {
-
-                }
-
-                @Override
-                public void cardActionDown() {
-
-                }
-
-                @Override
-                public void cardActionUp() {
-
-                }
-            });
+            CardContainer card = new CardContainer(newBottomChild, this, new CardContainerCallback(viewId));
 
             card.setPositionWithinAdapter(adapterIndex);
 
@@ -262,46 +221,7 @@ public class SwipeDeck extends FrameLayout {
 
             final long viewId = mAdapter.getItemId(positionOfLastCard);
 
-            CardContainer card = new CardContainer(newBottomChild, this, new SwipeCallback() {
-                @Override
-                public void cardSwipedLeft(View card) {
-                    Log.d(TAG, "card swiped left");
-                    if (!(deck.getFront().getCard() == card)) {
-                        Log.e("SWIPE ERROR: ", "card on top of deck not equal to card swiped");
-                    }
-                    deck.removeFront();
-                    if (callback != null) {
-                        callback.cardSwipedLeft(viewId);
-                    }
-                }
-
-                @Override
-                public void cardSwipedRight(View card) {
-                    Log.d(TAG, "card swiped right");
-                    if (!(deck.getFront().getCard() == card)) {
-                        Log.e("SWIPE ERROR: ", "card on top of deck not equal to card swiped");
-                    }
-                    deck.removeFront();
-                    if (callback != null) {
-                        callback.cardSwipedRight(viewId);
-                    }
-                }
-
-                @Override
-                public void cardOffScreen(View card) {
-
-                }
-
-                @Override
-                public void cardActionDown() {
-
-                }
-
-                @Override
-                public void cardActionUp() {
-
-                }
-            });
+            CardContainer card = new CardContainer(newBottomChild, this, new CardContainerCallback(viewId));
 
             if (leftImageResource != 0) {
                 card.setLeftImageResource(leftImageResource);
@@ -427,9 +347,76 @@ public class SwipeDeck extends FrameLayout {
     }
 
     public interface SwipeDeckCallback {
-        void cardSwipedLeft(long stableId);
+        void cardSwipedLeft(long itemId);
 
-        void cardSwipedRight(long stableId);
+        void cardSwipedRight(long itemId);
+
+        /**
+         * Check whether we can start dragging view with provided id.
+         *
+         * @param itemId id of the card returned by adapter's {@link Adapter#getItemId(int)}
+         * @return true if we can start dragging view, false otherwise
+         */
+        boolean isDragEnabled(long itemId);
+    }
+
+    private class CardContainerCallback implements SwipeCallback {
+
+        private final long viewId;
+
+        public CardContainerCallback(long viewId) {
+            this.viewId = viewId;
+        }
+
+        @Override
+        public void cardSwipedLeft(View card) {
+            Log.d(TAG, "card swiped left");
+            if (!(deck.getFront().getCard() == card)) {
+                Log.e("SWIPE ERROR: ", "card on top of deck not equal to card swiped");
+            }
+            deck.removeFront();
+            if (callback != null) {
+                callback.cardSwipedLeft(viewId);
+            }
+        }
+
+        @Override
+        public void cardSwipedRight(View card) {
+            Log.d(TAG, "card swiped right");
+            if (!(deck.getFront().getCard() == card)) {
+                Log.e("SWIPE ERROR: ", "card on top of deck not equal to card swiped");
+            }
+            deck.removeFront();
+            if (callback != null) {
+                callback.cardSwipedRight(viewId);
+            }
+        }
+
+        @Override
+        public boolean isDragEnabled() {
+            if (callback != null) {
+                return callback.isDragEnabled(viewId);
+            } else {
+                // Enabled by default, drag would depend on SWIPE_ENABLED
+                return true;
+            }
+        }
+
+        @Override
+        public void cardOffScreen(View card) {
+
+        }
+
+        @Override
+        public void cardActionDown() {
+
+        }
+
+        @Override
+        public void cardActionUp() {
+
+        }
+
     }
 }
 

--- a/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/SwipeDeck.java
+++ b/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/SwipeDeck.java
@@ -323,6 +323,19 @@ public class SwipeDeck extends FrameLayout {
         return this.adapterIndex;
     }
 
+    /**
+     * Get item id associated with the card on top of the deck.
+     *
+     * @return item id of the card on the top of the stack or -1 if deck is empty
+     */
+    public long getTopCardItemId() {
+        if (deck.size() > 0) {
+            return deck.getFront().getId();
+        } else {
+            return -1;
+        }
+    }
+
     public void removeFromBuffer(CardContainer container) {
         this.buffer.remove(container);
     }

--- a/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/Utility/SwipeCallback.java
+++ b/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/Utility/SwipeCallback.java
@@ -11,4 +11,10 @@ public interface SwipeCallback {
     void cardOffScreen(View card);
     void cardActionDown();
     void cardActionUp();
+
+    /**
+     * Check whether we can start dragging current view.
+     * @return true if we can start dragging view, false otherwise
+     */
+    boolean isDragEnabled();
 }

--- a/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/Utility/SwipeListener.java
+++ b/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/Utility/SwipeListener.java
@@ -1,5 +1,7 @@
 package com.daprlabs.aaron.swipedeck.Utility;
 
+import com.daprlabs.aaron.swipedeck.SwipeDeck;
+
 import android.animation.Animator;
 import android.util.Log;
 import android.view.MotionEvent;
@@ -7,10 +9,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewPropertyAnimator;
 import android.view.animation.OvershootInterpolator;
-
-import com.daprlabs.aaron.swipedeck.SwipeDeck;
-
-import java.util.ArrayList;
 
 /**
  * Created by aaron on 4/12/2015.
@@ -34,26 +32,6 @@ public class SwipeListener implements View.OnTouchListener {
     private boolean deactivated;
     private View rightView;
     private View leftView;
-
-
-    //new animation vars
-    private ArrayList<View> underCards;
-    private int cardSpacing;
-    private int xScale;
-    private String TAG = "SwipeListener";
-
-
-    public SwipeListener(View card, final SwipeCallback callback, int initialX, int initialY, float rotation, float opacityEnd) {
-        this.card = card;
-        this.initialX = initialX;
-        this.initialY = initialY;
-        this.callback = callback;
-        this.parent = (ViewGroup) card.getParent();
-        this.parentWidth = parent.getWidth();
-        this.ROTATION_DEGREES = rotation;
-        this.OPACITY_END = opacityEnd;
-        this.paddingLeft = ((ViewGroup) card.getParent()).getPaddingLeft();
-    }
 
     public SwipeListener(View card, final SwipeCallback callback, int initialX, int initialY, float rotation, float opacityEnd, SwipeDeck parent) {
         this.card = card;
@@ -97,6 +75,10 @@ public class SwipeListener implements View.OnTouchListener {
 
             case MotionEvent.ACTION_MOVE:
                 //gesture is in progress
+                // Check whether we are allowed to drag this card
+                if (!callback.isDragEnabled()) {
+                    return false;
+                }
 
                 final int pointerIndex = event.findPointerIndex(mActivePointerId);
                 //Log.i("pointer index: " , Integer.toString(pointerIndex));

--- a/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/Utility/SwipeListener.java
+++ b/swipedeck/src/main/java/com/daprlabs/aaron/swipedeck/Utility/SwipeListener.java
@@ -75,10 +75,6 @@ public class SwipeListener implements View.OnTouchListener {
 
             case MotionEvent.ACTION_MOVE:
                 //gesture is in progress
-                // Check whether we are allowed to drag this card
-                if (!callback.isDragEnabled()) {
-                    return false;
-                }
 
                 final int pointerIndex = event.findPointerIndex(mActivePointerId);
                 //Log.i("pointer index: " , Integer.toString(pointerIndex));
@@ -93,6 +89,18 @@ public class SwipeListener implements View.OnTouchListener {
                 final float dx = xMove - initialXPress;
                 final float dy = yMove - initialYPress;
 
+                //in this circumstance consider the motion a click
+                if (Math.abs(dx + dy) > 5) {
+                    click = false;
+                }
+
+                // Check whether we are allowed to drag this card
+                // We don't want to do this at the start of the branch, as we need to check whether we exceeded
+                // moving threshold first
+                if (!callback.isDragEnabled()) {
+                    return false;
+                }
+
                 Log.d("X:" , "" + v.getX());
 
                 //throw away the move in this case as it seems to be wrong
@@ -104,9 +112,6 @@ public class SwipeListener implements View.OnTouchListener {
                 //calc rotation here
                 float posX = card.getX() + dx;
                 float posY = card.getY() + dy;
-
-                //in this circumstance consider the motion a click
-                if (Math.abs(dx + dy) > 5) click = false;
 
                 card.setX(posX);
                 card.setY(posY);


### PR DESCRIPTION
Hello, I'd like to propose adding two new API methods:

1. "isDragEnabled"
One of callback methods, invoked when user starts dragging card. If it returns false we won't start dragging.
Use-case - I have a card, that user needs to interact with before he can swipe it. (He should click it and reveal contents). 
Another use case - card is showing some data that needs to be loaded, we don't want to allow to swipe it until it finished loading.
While we can change this by SWIPE_ENABLED, it makes more sense to check this for particular card only.

2. "getTopCardItemId"
Right now, we have no way to know which card is shown at the top of the deck. We do have "getAdapterIndex" but it returns index of the item on the bottom of displayed deck.
Personally, I would've preferred to have this return adapter position, but it seems in the recent update you've switched to using itemIds, so I've made it similar.

I've updated example app, and added checkbox to switch dragging behavior.